### PR TITLE
React 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 /umd
 npm-debug.log*
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ A `<Form>` component renders a `<form>` element with the contents you provide, h
 
 ```js
 import React from 'react'
+import createReactClass from 'create-react-class'
 import Form from 'react-router-form'
 
-let NewPost = React.createClass({
+let NewPost = createReactClass({
   render() {
     <Form to={`/topics/${this.props.params.topicId}/add-post`} method="POST">
       <textarea name="comment"/>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,6 +1,7 @@
 import './style.css'
 
 import React from 'react'
+import createReactClass from 'create-react-class'
 import {render} from 'react-dom'
 import {IndexRoute, Link, Route, Router, hashHistory} from 'react-router'
 
@@ -62,7 +63,7 @@ let ContactService = {
   }
 }
 
-let App = React.createClass({
+let App = createReactClass({
   render() {
     return <div className="App">
       <p>
@@ -76,7 +77,7 @@ let App = React.createClass({
   }
 })
 
-let Contacts = React.createClass({
+let Contacts = createReactClass({
   render() {
     return <div>
       <h2>Contacts</h2>
@@ -93,7 +94,7 @@ let Contacts = React.createClass({
   }
 })
 
-let NewContact = React.createClass({
+let NewContact = createReactClass({
   getInitialState() {
     return {
       error: null

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "prop-types": "15.x"
   },
   "peerDependencies": {
-    "react": "15.x",
+    "react": "16.x",
     "react-router": "3.x"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "4.8.x",
     "nwb": "0.16.x",
-    "react": "15.x",
-    "react-dom": "15.x",
+    "react": "16.x",
+    "react-dom": "16.x",
     "react-router": "3.x"
   },
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
+    "create-react-class": "15.x",
     "get-form-data": "1.x",
     "invariant": "2.x",
     "prop-types": "15.x"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "get-form-data": "1.x",
-    "invariant": "2.x"
+    "invariant": "2.x",
+    "prop-types": "15.x"
   },
   "peerDependencies": {
     "react": "15.x",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
   "devDependencies": {
     "eslint-config-jonnybuchanan": "4.8.x",
     "nwb": "0.16.x",
-
     "react": "15.x",
     "react-addons-test-utils": "15.x",
     "react-dom": "15.x",
-
     "react-router": "3.x"
   },
   "author": "Jonny Buchanan <jonathan.buchanan@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint-config-jonnybuchanan": "4.8.x",
     "nwb": "0.16.x",
     "react": "15.x",
-    "react-addons-test-utils": "15.x",
     "react-dom": "15.x",
     "react-router": "3.x"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import getFormData from 'get-form-data'
 import invariant from 'invariant'
 import React from 'react'
 import PropTypes from 'prop-types'
+import createReactClass from 'create-react-class'
 
 const {any, func, number, object, oneOfType, shape, string} = PropTypes
 
@@ -102,7 +103,7 @@ function ContextSubscriber(name) {
  *
  *   <Form to={`/topics/${topicId}/add-post`} method="POST">
  */
-const Form = React.createClass({
+const Form = createReactClass({
   displayName: 'Form',
 
   mixins: [ContextSubscriber('router')],

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import getFormData from 'get-form-data'
 import invariant from 'invariant'
 import React from 'react'
+import PropTypes from 'prop-types'
 
-const {any, func, number, object, oneOfType, shape, string} = React.PropTypes
+const {any, func, number, object, oneOfType, shape, string} = PropTypes
 
 const {toString} = Object.prototype
 

--- a/tests/Form-test.js
+++ b/tests/Form-test.js
@@ -3,7 +3,7 @@ import createHistory from 'react-router/lib/createMemoryHistory'
 import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 import {Router, Route} from 'react-router'
-import {Simulate} from 'react-addons-test-utils'
+import {Simulate} from 'react-dom/test-utils'
 
 import Form from 'src/index'
 


### PR DESCRIPTION
This PR is a superset of the changes purposed in https://github.com/insin/react-router-form/pull/10.

I'd love for this package to be compatible with React 16. However, I'm not sure about your backwards compatibility policy. Do you intend to maintain compatibility with 15.x? We could modify the version constraint to allow for both ranges.